### PR TITLE
tox: Just set python3 in base target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ skipsdist=True
 envlist = pycodestyle, pylint
 
 [testenv]
+basepython = python3
 usedevelop = true
 passenv =
     SSH_AUTH_SOCK
@@ -15,7 +16,6 @@ deps =
   -rrequirements.txt
 
 [testenv:pycodestyle]
-basepython = python3
 # E501: line too long (80 chars)
 commands =
     -sh -c 'pycodestyle --ignore=E501 wazo_acceptance > pycodestyle.txt'
@@ -25,7 +25,6 @@ whitelist_externals =
     sh
 
 [testenv:pylint]
-basepython = python3
 commands =
     -sh -c 'pylint --rcfile=/usr/share/xivo-ci/pylintrc wazo_acceptance > pylint.txt'
 deps =
@@ -35,7 +34,6 @@ whitelist_externals =
     sh
 
 [testenv:setup]
-basepython = python3
 envdir={toxworkdir}/acceptance
 setenv =
   CONFIG_PATH = ~/.wazo-acceptance/config.yml
@@ -50,7 +48,6 @@ whitelist_externals =
   bash
 
 [testenv:behave]
-basepython = python3
 envdir={toxworkdir}/acceptance
 commands =
   behave {posargs}


### PR DESCRIPTION
All targets use python, we can just set it on base target